### PR TITLE
Add atari st compression support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /scrap
 /gallery/
 /dist/
+.parcel-cache

--- a/_script/fileformats/png.js
+++ b/_script/fileformats/png.js
@@ -61,8 +61,8 @@ let IndexedPng = function(){
         let index = file.index;
         let data;
         let len = file.readUint();
-        let type = file.readBytes(4);
-        if (includeData) data = file.readBytes(len);
+        let type = file.readUBytes(4);
+        if (includeData) data = file.readUBytes(len);
         let crc = file.readUint();
 
         file.goto(index + 4 + 4 + len + 4);
@@ -145,7 +145,7 @@ let IndexedPng = function(){
 
     // detect 8-bit indexed PNG
     me.detect = file=>{
-        let header = file.readBytes(8, 0);
+        let header = file.readUBytes(8, 0);
         let isIndexedPng = isArrayEqual(header, pngHeader);
         if (isIndexedPng){
             // according to specs the IHDR chunk should be the first chunk

--- a/_script/util/binarystream.js
+++ b/_script/util/binarystream.js
@@ -71,18 +71,36 @@ function BinaryStream(arrayBuffer, bigEndian){
 		return i;
 	};
 
+	obj.readUWord = function(position) {
+		setIndex(position);
+		var i = this.dataView.getUint16(this.index, this.littleEndian);
+		this.index += 2;
+		return i;
+	}
+
 	obj.writeUint = function(value,position){
 		setIndex(position);
 		this.dataView.setUint32(this.index,value,this.litteEndian);
 		this.index+=4;
 	};
 
-	obj.readBytes = function(len,position,buffer) {
+	obj.readUBytes = function(len,position,buffer) {
 		setIndex(position);
 		if (!buffer) buffer = new Uint8Array(len);
 		var i = this.index;
 		var offset = 0;
 		for (; offset < len; offset++) buffer[offset] = this.dataView.getUint8(i+offset);
+
+		this.index += len;
+		return buffer;
+	};
+
+	obj.readBytes = function(len,position,buffer) {
+		setIndex(position);
+		if (!buffer) buffer = new Int8Array(len);
+		var i = this.index;
+		var offset = 0;
+		for (; offset < len; offset++) buffer[offset] = this.dataView.getInt8(i+offset);
 
 		this.index += len;
 		return buffer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,13 @@
                 "eslint-plugin-prettier": "^4.2.1"
             },
             "devDependencies": {
-                "@parcel/packager-raw-url": "^2.11.0",
-                "@parcel/transformer-webmanifest": "^2.11.0",
+                "@parcel/packager-raw-url": "^2.12.0",
+                "@parcel/transformer-webmanifest": "^2.12.0",
                 "assert": "^2.0.0",
                 "browserify-zlib": "^0.2.0",
                 "buffer": "^5.5.0",
                 "events": "^3.1.0",
+                "parcel": "^2.12.0",
                 "process": "^0.11.10",
                 "stream-browserify": "^3.0.0",
                 "util": "^0.12.3"
@@ -30,6 +31,114 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/highlight": "^7.24.7",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "chalk": "^2.4.2",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -341,15 +450,37 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@parcel/cache": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.11.0.tgz",
-            "integrity": "sha512-RSSkGNjO00lJPyftzaC9eaNVs4jMjPSAm0VJNWQ9JSm2n4A9BzQtTFAt1vhJOzzW1UsQvvBge9DdfkB7a2gIOw==",
+        "node_modules/@parcel/bundler-default": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
+            "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
             "dev": true,
             "dependencies": {
-                "@parcel/fs": "2.11.0",
-                "@parcel/logger": "2.11.0",
-                "@parcel/utils": "2.11.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/graph": "3.2.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/cache": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
+            "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/fs": "2.12.0",
+                "@parcel/logger": "2.12.0",
+                "@parcel/utils": "2.12.0",
                 "lmdb": "2.8.5"
             },
             "engines": {
@@ -360,13 +491,13 @@
                 "url": "https://opencollective.com/parcel"
             },
             "peerDependencies": {
-                "@parcel/core": "^2.11.0"
+                "@parcel/core": "^2.12.0"
             }
         },
         "node_modules/@parcel/codeframe": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.11.0.tgz",
-            "integrity": "sha512-YHs9g/i5af/sd/JrWAojU9YFbKffcJ3Tx2EJaK0ME8OJsye91UaI/3lxSUYLmJG9e4WLNJtqci8V5FBMz//ZPg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
+            "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0"
@@ -379,28 +510,90 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/@parcel/core": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.11.0.tgz",
-            "integrity": "sha512-Npe0S6hVaqWEwRL+HI7gtOYOaoE5bJQZTgUDhsDoppWbau51jOlRYOZTXuvRK/jxXnze4/S1sdM24xBYAQ5qkw==",
+        "node_modules/@parcel/compressor-raw": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
+            "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
             "dev": true,
-            "peer": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/config-default": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
+            "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/bundler-default": "2.12.0",
+                "@parcel/compressor-raw": "2.12.0",
+                "@parcel/namer-default": "2.12.0",
+                "@parcel/optimizer-css": "2.12.0",
+                "@parcel/optimizer-htmlnano": "2.12.0",
+                "@parcel/optimizer-image": "2.12.0",
+                "@parcel/optimizer-svgo": "2.12.0",
+                "@parcel/optimizer-swc": "2.12.0",
+                "@parcel/packager-css": "2.12.0",
+                "@parcel/packager-html": "2.12.0",
+                "@parcel/packager-js": "2.12.0",
+                "@parcel/packager-raw": "2.12.0",
+                "@parcel/packager-svg": "2.12.0",
+                "@parcel/packager-wasm": "2.12.0",
+                "@parcel/reporter-dev-server": "2.12.0",
+                "@parcel/resolver-default": "2.12.0",
+                "@parcel/runtime-browser-hmr": "2.12.0",
+                "@parcel/runtime-js": "2.12.0",
+                "@parcel/runtime-react-refresh": "2.12.0",
+                "@parcel/runtime-service-worker": "2.12.0",
+                "@parcel/transformer-babel": "2.12.0",
+                "@parcel/transformer-css": "2.12.0",
+                "@parcel/transformer-html": "2.12.0",
+                "@parcel/transformer-image": "2.12.0",
+                "@parcel/transformer-js": "2.12.0",
+                "@parcel/transformer-json": "2.12.0",
+                "@parcel/transformer-postcss": "2.12.0",
+                "@parcel/transformer-posthtml": "2.12.0",
+                "@parcel/transformer-raw": "2.12.0",
+                "@parcel/transformer-react-refresh-wrap": "2.12.0",
+                "@parcel/transformer-svg": "2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "peerDependencies": {
+                "@parcel/core": "^2.12.0"
+            }
+        },
+        "node_modules/@parcel/core": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
+            "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
+            "dev": true,
             "dependencies": {
                 "@mischnic/json-sourcemap": "^0.1.0",
-                "@parcel/cache": "2.11.0",
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/events": "2.11.0",
-                "@parcel/fs": "2.11.0",
-                "@parcel/graph": "3.1.0",
-                "@parcel/logger": "2.11.0",
-                "@parcel/package-manager": "2.11.0",
-                "@parcel/plugin": "2.11.0",
-                "@parcel/profiler": "2.11.0",
-                "@parcel/rust": "2.11.0",
+                "@parcel/cache": "2.12.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/events": "2.12.0",
+                "@parcel/fs": "2.12.0",
+                "@parcel/graph": "3.2.0",
+                "@parcel/logger": "2.12.0",
+                "@parcel/package-manager": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/profiler": "2.12.0",
+                "@parcel/rust": "2.12.0",
                 "@parcel/source-map": "^2.1.1",
-                "@parcel/types": "2.11.0",
-                "@parcel/utils": "2.11.0",
-                "@parcel/workers": "2.11.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "@parcel/workers": "2.12.0",
                 "abortcontroller-polyfill": "^1.1.9",
                 "base-x": "^3.0.8",
                 "browserslist": "^4.6.6",
@@ -421,9 +614,9 @@
             }
         },
         "node_modules/@parcel/diagnostic": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.11.0.tgz",
-            "integrity": "sha512-4dJmOXVL5YGGQRRsQosQbSRONBcboB71mSwaeaEgz3pPdq9QXVPLACkGe/jTXSqa3OnAHu3g5vQLpE1g5xqBqw==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
+            "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
             "dev": true,
             "dependencies": {
                 "@mischnic/json-sourcemap": "^0.1.0",
@@ -438,9 +631,9 @@
             }
         },
         "node_modules/@parcel/events": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.11.0.tgz",
-            "integrity": "sha512-K6SOjOrQsz1GdNl2qKBktq7KJ3Q3yxK8WXdmQYo10wG39dr051xtMb38aqieTp4eVhL8Yaq2iJgGkdr11fuBnA==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
+            "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
             "dev": true,
             "engines": {
                 "node": ">= 12.0.0"
@@ -451,16 +644,16 @@
             }
         },
         "node_modules/@parcel/fs": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.11.0.tgz",
-            "integrity": "sha512-zWckdnnovdrgdFX4QYuQV4bbKCsh6IYCkmwaB4yp47rhw1MP0lkBINLt4yFPHBxWXOpElCfxjL+z69c9xJQRBQ==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
+            "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
             "dev": true,
             "dependencies": {
-                "@parcel/rust": "2.11.0",
-                "@parcel/types": "2.11.0",
-                "@parcel/utils": "2.11.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
                 "@parcel/watcher": "^2.0.7",
-                "@parcel/workers": "2.11.0"
+                "@parcel/workers": "2.12.0"
             },
             "engines": {
                 "node": ">= 12.0.0"
@@ -470,15 +663,14 @@
                 "url": "https://opencollective.com/parcel"
             },
             "peerDependencies": {
-                "@parcel/core": "^2.11.0"
+                "@parcel/core": "^2.12.0"
             }
         },
         "node_modules/@parcel/graph": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.1.0.tgz",
-            "integrity": "sha512-d1dTW5C7A52HgDtoXlyvlET1ypSlmIxSIZOJ1xp3R9L9hgo3h1u3jHNyaoTe/WPkGVe2QnFxh0h+UibVJhu9vg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
+            "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "nullthrows": "^1.1.1"
             },
@@ -491,13 +683,13 @@
             }
         },
         "node_modules/@parcel/logger": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.11.0.tgz",
-            "integrity": "sha512-HtMEdCq3LKnvv4T2CIskcqlf2gpBvHMm3pkeUFB/hc/7hW/hE1k6/HA2VOQvc0tBsaMpmEx7PCrfrH56usQSyA==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
+            "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
             "dev": true,
             "dependencies": {
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/events": "2.11.0"
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/events": "2.12.0"
             },
             "engines": {
                 "node": ">= 12.0.0"
@@ -508,9 +700,9 @@
             }
         },
         "node_modules/@parcel/markdown-ansi": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.11.0.tgz",
-            "integrity": "sha512-YA60EWbXi6cLOIzcwRC2wijotPauOGQbUi0vSbu0O6/mjQ68kWCMGz0hwZjDRQcPypQVJEIvTgMymLbvumxwhg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
+            "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.1.0"
@@ -523,17 +715,36 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@parcel/namer-default": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
+            "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@parcel/node-resolver-core": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.2.0.tgz",
-            "integrity": "sha512-XJRSxCkNbGFWjfmwFdcQZ/qlzWZd35qLtvLz2va8euGL7M5OMEQOv7dsvEhl0R+CC2zcnfFzZwxk78q6ezs8AQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
+            "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
             "dev": true,
             "dependencies": {
                 "@mischnic/json-sourcemap": "^0.1.0",
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/fs": "2.11.0",
-                "@parcel/rust": "2.11.0",
-                "@parcel/utils": "2.11.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/fs": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/utils": "2.12.0",
                 "nullthrows": "^1.1.1",
                 "semver": "^7.5.2"
             },
@@ -545,19 +756,266 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/@parcel/package-manager": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.11.0.tgz",
-            "integrity": "sha512-QzdsrUYlAwIzb8by7WJjqYnbR1MoMKWbtE1MXUeYsZbFusV8B6pOH+lwqNJKS/BFtddZMRPYFueZS2N2fwzjig==",
+        "node_modules/@parcel/optimizer-css": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
+            "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
             "dev": true,
             "dependencies": {
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/fs": "2.11.0",
-                "@parcel/logger": "2.11.0",
-                "@parcel/node-resolver-core": "3.2.0",
-                "@parcel/types": "2.11.0",
-                "@parcel/utils": "2.11.0",
-                "@parcel/workers": "2.11.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/utils": "2.12.0",
+                "browserslist": "^4.6.6",
+                "lightningcss": "^1.22.1",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/optimizer-htmlnano": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
+            "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "htmlnano": "^2.0.0",
+                "nullthrows": "^1.1.1",
+                "posthtml": "^0.16.5",
+                "svgo": "^2.4.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/optimizer-htmlnano/node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/@parcel/optimizer-htmlnano/node_modules/css-tree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "dev": true,
+            "dependencies": {
+                "mdn-data": "2.0.14",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-htmlnano/node_modules/csso": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+            "dev": true,
+            "dependencies": {
+                "css-tree": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-htmlnano/node_modules/mdn-data": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "dev": true
+        },
+        "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "dev": true,
+            "dependencies": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^4.1.3",
+                "css-tree": "^1.1.3",
+                "csso": "^4.2.0",
+                "picocolors": "^1.0.0",
+                "stable": "^0.1.8"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-image": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
+            "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "@parcel/workers": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "peerDependencies": {
+                "@parcel/core": "^2.12.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-svgo": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
+            "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "svgo": "^2.4.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/optimizer-svgo/node_modules/css-select": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+            "dev": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
+                "domutils": "^2.8.0",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/@parcel/optimizer-svgo/node_modules/css-tree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+            "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+            "dev": true,
+            "dependencies": {
+                "mdn-data": "2.0.14",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-svgo/node_modules/csso": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+            "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+            "dev": true,
+            "dependencies": {
+                "css-tree": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-svgo/node_modules/mdn-data": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+            "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "dev": true
+        },
+        "node_modules/@parcel/optimizer-svgo/node_modules/svgo": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+            "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+            "dev": true,
+            "dependencies": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^4.1.3",
+                "css-tree": "^1.1.3",
+                "csso": "^4.2.0",
+                "picocolors": "^1.0.0",
+                "stable": "^0.1.8"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/@parcel/optimizer-swc": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
+            "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/utils": "2.12.0",
+                "@swc/core": "^1.3.36",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/package-manager": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
+            "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/fs": "2.12.0",
+                "@parcel/logger": "2.12.0",
+                "@parcel/node-resolver-core": "3.3.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "@parcel/workers": "2.12.0",
+                "@swc/core": "^1.3.36",
                 "semver": "^7.5.2"
             },
             "engines": {
@@ -568,21 +1026,142 @@
                 "url": "https://opencollective.com/parcel"
             },
             "peerDependencies": {
-                "@parcel/core": "^2.11.0"
+                "@parcel/core": "^2.12.0"
             }
         },
-        "node_modules/@parcel/packager-raw-url": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/packager-raw-url/-/packager-raw-url-2.11.0.tgz",
-            "integrity": "sha512-CAa+zTXRotlAgb0eRg//NBVaXRsomWowl7weWeOgRDCq80gqPLAli9k5N9l+048gBiY+OORRtMRM32QgO59tfg==",
+        "node_modules/@parcel/packager-css": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
+            "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
             "dev": true,
             "dependencies": {
-                "@parcel/plugin": "2.11.0",
-                "@parcel/utils": "2.11.0"
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/utils": "2.12.0",
+                "lightningcss": "^1.22.1",
+                "nullthrows": "^1.1.1"
             },
             "engines": {
                 "node": ">= 12.0.0",
-                "parcel": "^2.11.0"
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/packager-html": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
+            "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "nullthrows": "^1.1.1",
+                "posthtml": "^0.16.5"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/packager-js": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
+            "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "globals": "^13.2.0",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/packager-raw": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
+            "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/packager-raw-url": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-raw-url/-/packager-raw-url-2.12.0.tgz",
+            "integrity": "sha512-sH7cvLbotS+qknhQUCGfd9mslQr4KcanlZE5CgzM0uGn3SnyZoKznqHrbouzgnIP/LHgXKOKmMaNjPLtVe4rcA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/packager-svg": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
+            "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "posthtml": "^0.16.4"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/packager-wasm": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
+            "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "parcel": "^2.12.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -590,12 +1169,12 @@
             }
         },
         "node_modules/@parcel/plugin": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.11.0.tgz",
-            "integrity": "sha512-9npuKBlhnPn7oeUpLJGecceg16GkXbvzbr6MNSZiHhkx3IBeITHQXlZnp2zAjUOFreNsYOfifwEF2S4KsARfBQ==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
+            "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
             "dev": true,
             "dependencies": {
-                "@parcel/types": "2.11.0"
+                "@parcel/types": "2.12.0"
             },
             "engines": {
                 "node": ">= 12.0.0"
@@ -606,13 +1185,13 @@
             }
         },
         "node_modules/@parcel/profiler": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.11.0.tgz",
-            "integrity": "sha512-s10SS09prOdwnaAcjK8M5zO8o+zPJJW5oOqXPNdf6KH4NGD/ue7iOk2xM8QLw6ulSwxE7NDt++lyfW3AXgCZwg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
+            "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
             "dev": true,
             "dependencies": {
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/events": "2.11.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/events": "2.12.0",
                 "chrome-trace-event": "^1.0.2"
             },
             "engines": {
@@ -623,10 +1202,164 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@parcel/reporter-cli": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.12.0.tgz",
+            "integrity": "sha512-TqKsH4GVOLPSCanZ6tcTPj+rdVHERnt5y4bwTM82cajM21bCX1Ruwp8xOKU+03091oV2pv5ieB18pJyRF7IpIw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "chalk": "^4.1.0",
+                "term-size": "^2.2.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/reporter-dev-server": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
+            "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/reporter-tracer": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
+            "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "chrome-trace-event": "^1.0.3",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/resolver-default": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
+            "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/node-resolver-core": "3.3.0",
+                "@parcel/plugin": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/runtime-browser-hmr": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
+            "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/runtime-js": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
+            "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/runtime-react-refresh": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
+            "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "react-error-overlay": "6.0.9",
+                "react-refresh": "^0.9.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/runtime-service-worker": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
+            "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@parcel/rust": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.11.0.tgz",
-            "integrity": "sha512-UkLWdHOD8Md2YmJDPsqd3yIs9chhdl/ATfV/B/xdPKGmqtNouYpDCRlq+WxMt3mLoYgHEg9UwrWLTebo2rr2iQ==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
+            "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
             "dev": true,
             "engines": {
                 "node": ">= 12.0.0"
@@ -648,19 +1381,277 @@
                 "node": "^12.18.3 || >=14"
             }
         },
+        "node_modules/@parcel/transformer-babel": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
+            "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/utils": "2.12.0",
+                "browserslist": "^4.6.6",
+                "json5": "^2.2.0",
+                "nullthrows": "^1.1.1",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-css": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
+            "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/utils": "2.12.0",
+                "browserslist": "^4.6.6",
+                "lightningcss": "^1.22.1",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-html": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
+            "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "nullthrows": "^1.1.1",
+                "posthtml": "^0.16.5",
+                "posthtml-parser": "^0.10.1",
+                "posthtml-render": "^3.0.0",
+                "semver": "^7.5.2",
+                "srcset": "4"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-html/node_modules/srcset": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
+            "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@parcel/transformer-image": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
+            "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "@parcel/workers": "2.12.0",
+                "nullthrows": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "peerDependencies": {
+                "@parcel/core": "^2.12.0"
+            }
+        },
+        "node_modules/@parcel/transformer-js": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
+            "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/source-map": "^2.1.1",
+                "@parcel/utils": "2.12.0",
+                "@parcel/workers": "2.12.0",
+                "@swc/helpers": "^0.5.0",
+                "browserslist": "^4.6.6",
+                "nullthrows": "^1.1.1",
+                "regenerator-runtime": "^0.13.7",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "peerDependencies": {
+                "@parcel/core": "^2.12.0"
+            }
+        },
+        "node_modules/@parcel/transformer-json": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
+            "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "json5": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-postcss": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
+            "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "clone": "^2.1.1",
+                "nullthrows": "^1.1.1",
+                "postcss-value-parser": "^4.2.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-posthtml": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
+            "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "nullthrows": "^1.1.1",
+                "posthtml": "^0.16.5",
+                "posthtml-parser": "^0.10.1",
+                "posthtml-render": "^3.0.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-raw": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
+            "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-react-refresh-wrap": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
+            "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "react-refresh": "^0.9.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/transformer-svg": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
+            "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/rust": "2.12.0",
+                "nullthrows": "^1.1.1",
+                "posthtml": "^0.16.5",
+                "posthtml-parser": "^0.10.1",
+                "posthtml-render": "^3.0.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0",
+                "parcel": "^2.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@parcel/transformer-webmanifest": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/transformer-webmanifest/-/transformer-webmanifest-2.11.0.tgz",
-            "integrity": "sha512-15DAZX1NOT30L8yzbmYJxwWtHprQ8Zpg5+981IlS6X0YbsdIFq4BRhjfO+ZNOP0tDJe2pjJjcxPAtbubG5MJAw==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/transformer-webmanifest/-/transformer-webmanifest-2.12.0.tgz",
+            "integrity": "sha512-suiUv9DDEpyryHtzahbIeJSZTIeE/t4cdrU0Ikb/O46wsy5RLo59nE4E6TGWM84R7fQO8m/MhzeQM5Y3NV6jKg==",
             "dev": true,
             "dependencies": {
                 "@mischnic/json-sourcemap": "^0.1.0",
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/plugin": "2.11.0",
-                "@parcel/utils": "2.11.0"
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/plugin": "2.12.0",
+                "@parcel/utils": "2.12.0"
             },
             "engines": {
-                "parcel": "^2.11.0"
+                "parcel": "^2.12.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -668,31 +1659,31 @@
             }
         },
         "node_modules/@parcel/types": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.11.0.tgz",
-            "integrity": "sha512-lN5XlfV9b1s2rli8q1LqsLtu+D4ZwNI3sKmNcL/3tohSfQcF2EgF+MaiANGo9VzXOzoWFHt4dqWjO4OcdyC5tg==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
+            "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
             "dev": true,
             "dependencies": {
-                "@parcel/cache": "2.11.0",
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/fs": "2.11.0",
-                "@parcel/package-manager": "2.11.0",
+                "@parcel/cache": "2.12.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/fs": "2.12.0",
+                "@parcel/package-manager": "2.12.0",
                 "@parcel/source-map": "^2.1.1",
-                "@parcel/workers": "2.11.0",
+                "@parcel/workers": "2.12.0",
                 "utility-types": "^3.10.0"
             }
         },
         "node_modules/@parcel/utils": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.11.0.tgz",
-            "integrity": "sha512-AcL70cXlIyE7eQdvjQbYxegN5l+skqvlJllxTWg4YkIZe9p8Gmv74jLAeLWh5F+IGl5WRn0TSy9JhNJjIMQGwQ==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
+            "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
             "dev": true,
             "dependencies": {
-                "@parcel/codeframe": "2.11.0",
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/logger": "2.11.0",
-                "@parcel/markdown-ansi": "2.11.0",
-                "@parcel/rust": "2.11.0",
+                "@parcel/codeframe": "2.12.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/logger": "2.12.0",
+                "@parcel/markdown-ansi": "2.12.0",
+                "@parcel/rust": "2.12.0",
                 "@parcel/source-map": "^2.1.1",
                 "chalk": "^4.1.0",
                 "nullthrows": "^1.1.1"
@@ -980,16 +1971,16 @@
             }
         },
         "node_modules/@parcel/workers": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.11.0.tgz",
-            "integrity": "sha512-wjybqdSy6Nk0N9iBGsFcp7739W2zvx0WGfVxPVShqhz46pIkPOiFF/iSn+kFu5EmMKTRWeUif42+a6rRZ7pCnQ==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
+            "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
             "dev": true,
             "dependencies": {
-                "@parcel/diagnostic": "2.11.0",
-                "@parcel/logger": "2.11.0",
-                "@parcel/profiler": "2.11.0",
-                "@parcel/types": "2.11.0",
-                "@parcel/utils": "2.11.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/logger": "2.12.0",
+                "@parcel/profiler": "2.12.0",
+                "@parcel/types": "2.12.0",
+                "@parcel/utils": "2.12.0",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
@@ -1000,7 +1991,238 @@
                 "url": "https://opencollective.com/parcel"
             },
             "peerDependencies": {
-                "@parcel/core": "^2.11.0"
+                "@parcel/core": "^2.12.0"
+            }
+        },
+        "node_modules/@swc/core": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.1.tgz",
+            "integrity": "sha512-Yz5uj5hNZpS5brLtBvKY0L4s2tBAbQ4TjmW8xF1EC3YLFxQRrUjMP49Zm1kp/KYyYvTkSaG48Ffj2YWLu9nChw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.8"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.6.1",
+                "@swc/core-darwin-x64": "1.6.1",
+                "@swc/core-linux-arm-gnueabihf": "1.6.1",
+                "@swc/core-linux-arm64-gnu": "1.6.1",
+                "@swc/core-linux-arm64-musl": "1.6.1",
+                "@swc/core-linux-x64-gnu": "1.6.1",
+                "@swc/core-linux-x64-musl": "1.6.1",
+                "@swc/core-win32-arm64-msvc": "1.6.1",
+                "@swc/core-win32-ia32-msvc": "1.6.1",
+                "@swc/core-win32-x64-msvc": "1.6.1"
+            },
+            "peerDependencies": {
+                "@swc/helpers": "*"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.1.tgz",
+            "integrity": "sha512-u6GdwOXsOEdNAdSI6nWq6G2BQw5HiSNIZVcBaH1iSvBnxZvWbnIKyDiZKaYnDwTLHLzig2GuUjjE2NaCJPy4jg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.1.tgz",
+            "integrity": "sha512-/tXwQibkDNLVbAtr7PUQI0iQjoB708fjhDDDfJ6WILSBVZ3+qs/LHjJ7jHwumEYxVq1XA7Fv2Q7SE/ZSQoWHcQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.1.tgz",
+            "integrity": "sha512-aDgipxhJTms8iH78emHVutFR2c16LNhO+NTRCdYi+X4PyIn58/DyYTH6VDZ0AeEcS5f132ZFldU5AEgExwihXA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.1.tgz",
+            "integrity": "sha512-XkJ+eO4zUKG5g458RyhmKPyBGxI0FwfWFgpfIj5eDybxYJ6s4HBT5MoxyBLorB5kMlZ0XoY/usUMobPVY3nL0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.1.tgz",
+            "integrity": "sha512-dr6YbLBg/SsNxs1hDqJhxdcrS8dGMlOXJwXIrUvACiA8jAd6S5BxYCaqsCefLYXtaOmu0bbx1FB/evfodqB70Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.1.tgz",
+            "integrity": "sha512-A0b/3V+yFy4LXh3O9umIE7LXPC7NBWdjl6AQYqymSMcMu0EOb1/iygA6s6uWhz9y3e172Hpb9b/CGsuD8Px/bg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.1.tgz",
+            "integrity": "sha512-5dJjlzZXhC87nZZZWbpiDP8kBIO0ibis893F/rtPIQBI5poH+iJuA32EU3wN4/WFHeK4et8z6SGSVghPtWyk4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.1.tgz",
+            "integrity": "sha512-HBi1ZlwvfcUibLtT3g/lP57FaDPC799AD6InolB2KSgkqyBbZJ9wAXM8/CcH67GLIP0tZ7FqblrJTzGXxetTJQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.1.tgz",
+            "integrity": "sha512-AKqHohlWERclexar5y6ux4sQ8yaMejEXNxeKXm7xPhXrp13/1p4/I3E5bPVX/jMnvpm4HpcKSP0ee2WsqmhhPw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.1.tgz",
+            "integrity": "sha512-0dLdTLd+ONve8kgC5T6VQ2Y5G+OZ7y0ujjapnK66wpvCBM6BKYGdT/OKhZKZydrC5gUKaxFN6Y5oOt9JOFUrOQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "dev": true
+        },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
+            "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.8.tgz",
+            "integrity": "sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==",
+            "dev": true,
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
+            }
+        },
+        "node_modules/@trysound/sax": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -1013,8 +2235,7 @@
             "version": "1.7.5",
             "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
             "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/acorn": {
             "version": "8.11.3",
@@ -1079,8 +2300,7 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "peer": true
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/assert": {
             "version": "2.0.0",
@@ -1120,7 +2340,6 @@
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
             "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -1144,6 +2363,12 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1195,7 +2420,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001587",
                 "electron-to-chromium": "^1.4.668",
@@ -1256,7 +2480,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1279,8 +2502,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "peer": true
+            ]
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -1311,7 +2533,6 @@
             "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
             "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -1332,11 +2553,46 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "peer": true
+        },
+        "node_modules/cosmiconfig": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "dev": true,
+            "dependencies": {
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -1351,6 +2607,153 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/css-select": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-select/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/domutils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/css-select/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/css-tree": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "css-tree": "~2.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -1433,12 +2836,75 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ]
+        },
+        "node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dev": true,
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/dotenv": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
             "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1447,15 +2913,43 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/electron-to-chromium": {
             "version": "1.4.675",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.675.tgz",
             "integrity": "sha512-+1u3F/XPNIdUwv8i1lDxHAxCvNNU0QIqgb1Ycn+Jnng8ITzWSvUqixRSM7NOazJuwhf65IV17f/VbKj8DmL26A==",
+            "dev": true
+        },
+        "node_modules/entities": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
             "dev": true,
-            "peer": true
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
         },
         "node_modules/es-define-property": {
             "version": "1.0.0",
@@ -1489,7 +2983,6 @@
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
             "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1812,6 +3305,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-port": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+            "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1848,7 +3350,6 @@
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -1948,6 +3449,72 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/htmlnano": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.1.tgz",
+            "integrity": "sha512-kAERyg/LuNZYmdqgCdYvugyLWNFAm8MWXpQMz1pLpetmCbFwoMxvkSoaAMlFrOC4OKTWI4KlZGT/RsNxg4ghOw==",
+            "dev": true,
+            "dependencies": {
+                "cosmiconfig": "^9.0.0",
+                "posthtml": "^0.16.5",
+                "timsort": "^0.3.0"
+            },
+            "peerDependencies": {
+                "cssnano": "^7.0.0",
+                "postcss": "^8.3.11",
+                "purgecss": "^6.0.0",
+                "relateurl": "^0.2.7",
+                "srcset": "5.0.1",
+                "svgo": "^3.0.2",
+                "terser": "^5.10.0",
+                "uncss": "^0.17.3"
+            },
+            "peerDependenciesMeta": {
+                "cssnano": {
+                    "optional": true
+                },
+                "postcss": {
+                    "optional": true
+                },
+                "purgecss": {
+                    "optional": true
+                },
+                "relateurl": {
+                    "optional": true
+                },
+                "srcset": {
+                    "optional": true
+                },
+                "svgo": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "uncss": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.2",
+                "domutils": "^2.8.0",
+                "entities": "^3.0.1"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1981,7 +3548,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -2033,6 +3599,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
+        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2078,6 +3650,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-json": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+            "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
+            "dev": true
         },
         "node_modules/is-nan": {
             "version": "1.3.2",
@@ -2134,11 +3712,16 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "peer": true
         },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -2151,6 +3734,12 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "peer": true
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -2197,6 +3786,219 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.25.1.tgz",
+            "integrity": "sha512-V0RMVZzK1+rCHpymRv4URK2lNhIRyO8g7U7zOFwVAhJuat74HtkjIQpQRKNCwFEYkRGpafOpmXXLoaoBcyVtBg==",
+            "dev": true,
+            "dependencies": {
+                "detect-libc": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-darwin-arm64": "1.25.1",
+                "lightningcss-darwin-x64": "1.25.1",
+                "lightningcss-freebsd-x64": "1.25.1",
+                "lightningcss-linux-arm-gnueabihf": "1.25.1",
+                "lightningcss-linux-arm64-gnu": "1.25.1",
+                "lightningcss-linux-arm64-musl": "1.25.1",
+                "lightningcss-linux-x64-gnu": "1.25.1",
+                "lightningcss-linux-x64-musl": "1.25.1",
+                "lightningcss-win32-x64-msvc": "1.25.1"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.25.1.tgz",
+            "integrity": "sha512-G4Dcvv85bs5NLENcu/s1f7ehzE3D5ThnlWSDwE190tWXRQCQaqwcuHe+MGSVI/slm0XrxnaayXY+cNl3cSricw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.25.1.tgz",
+            "integrity": "sha512-dYWuCzzfqRueDSmto6YU5SoGHvZTMU1Em9xvhcdROpmtOQLorurUZz8+xFxZ51lCO2LnYbfdjZ/gCqWEkwixNg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.25.1.tgz",
+            "integrity": "sha512-hXoy2s9A3KVNAIoKz+Fp6bNeY+h9c3tkcx1J3+pS48CqAt+5bI/R/YY4hxGL57fWAIquRjGKW50arltD6iRt/w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.25.1.tgz",
+            "integrity": "sha512-tWyMgHFlHlp1e5iW3EpqvH5MvsgoN7ZkylBbG2R2LWxnvH3FuWCJOhtGcYx9Ks0Kv0eZOBud789odkYLhyf1ng==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.25.1.tgz",
+            "integrity": "sha512-Xjxsx286OT9/XSnVLIsFEDyDipqe4BcLeB4pXQ/FEA5+2uWCCuAEarUNQumRucnj7k6ftkAHUEph5r821KBccQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.25.1.tgz",
+            "integrity": "sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.25.1.tgz",
+            "integrity": "sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.25.1.tgz",
+            "integrity": "sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.25.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.25.1.tgz",
+            "integrity": "sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
         },
         "node_modules/lmdb": {
             "version": "2.8.5",
@@ -2261,6 +4063,14 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "dev": true,
+            "optional": true,
+            "peer": true
         },
         "node_modules/micromatch": {
             "version": "4.0.5",
@@ -2378,8 +4188,19 @@
             "version": "2.0.14",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
             "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+            "dev": true
+        },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
-            "peer": true
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
         },
         "node_modules/nullthrows": {
             "version": "1.1.1",
@@ -2480,16 +4301,65 @@
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
         },
+        "node_modules/parcel": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
+            "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
+            "dev": true,
+            "dependencies": {
+                "@parcel/config-default": "2.12.0",
+                "@parcel/core": "2.12.0",
+                "@parcel/diagnostic": "2.12.0",
+                "@parcel/events": "2.12.0",
+                "@parcel/fs": "2.12.0",
+                "@parcel/logger": "2.12.0",
+                "@parcel/package-manager": "2.12.0",
+                "@parcel/reporter-cli": "2.12.0",
+                "@parcel/reporter-dev-server": "2.12.0",
+                "@parcel/reporter-tracer": "2.12.0",
+                "@parcel/utils": "2.12.0",
+                "chalk": "^4.1.0",
+                "commander": "^7.0.0",
+                "get-port": "^4.2.0"
+            },
+            "bin": {
+                "parcel": "lib/bin.js"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/path-exists": {
@@ -2523,8 +4393,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -2545,6 +4414,61 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true
+        },
+        "node_modules/posthtml": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
+            "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+            "dev": true,
+            "dependencies": {
+                "posthtml-parser": "^0.11.0",
+                "posthtml-render": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/posthtml-parser": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
+            "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
+            "dev": true,
+            "dependencies": {
+                "htmlparser2": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/posthtml-render": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+            "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+            "dev": true,
+            "dependencies": {
+                "is-json": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/posthtml/node_modules/posthtml-parser": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+            "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+            "dev": true,
+            "dependencies": {
+                "htmlparser2": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/prelude-ls": {
@@ -2620,6 +4544,21 @@
             ],
             "peer": true
         },
+        "node_modules/react-error-overlay": {
+            "version": "6.0.9",
+            "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+            "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
+            "dev": true
+        },
+        "node_modules/react-refresh": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+            "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2634,11 +4573,16 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "dev": true
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -2764,6 +4708,47 @@
                 "node": ">=8"
             }
         },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/srcset": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/srcset/-/srcset-5.0.1.tgz",
+            "integrity": "sha512-/P1UYbGfJVlxZag7aABNRrulEXAwCSDo7fklafOQrantuPTDmYgijJMks2zusPCVzgW9+4P69mq7w6pYuZpgxw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stable": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+            "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+            "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+            "dev": true
+        },
         "node_modules/stream-browserify": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -2818,11 +4803,56 @@
                 "node": ">=8"
             }
         },
+        "node_modules/svgo": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+            "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^2.3.1",
+                "css-what": "^6.1.0",
+                "csso": "^5.0.5",
+                "picocolors": "^1.0.0"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
+            }
+        },
+        "node_modules/term-size": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+            "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "peer": true
+        },
+        "node_modules/timsort": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+            "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+            "dev": true
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -2835,6 +4865,12 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+            "dev": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -2852,7 +4888,6 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2879,7 +4914,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "author": "Steffest",
     "license": "MIT",
     "devDependencies": {
-        "@parcel/packager-raw-url": "^2.11.0",
-        "@parcel/transformer-webmanifest": "^2.11.0",
+        "@parcel/packager-raw-url": "^2.12.0",
+        "@parcel/transformer-webmanifest": "^2.12.0",
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
         "buffer": "^5.5.0",
         "events": "^3.1.0",
+        "parcel": "^2.12.0",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "util": "^0.12.3"


### PR DESCRIPTION
This PR adds support for [ByteRun2 compression](https://temlib.org/AtariForumWiki/index.php/IFF_file_format): files generated by the Atari ST version of Deluxe Paint use this compression method.

Bitplanes are compressed as columns.

After this PR, files coming from the Deluxe Paint Atari ST version can now be opened in DPaint-js:

![Capture d’écran 2024-06-20 à 17 41 24](https://github.com/steffest/DPaint-js/assets/199648/a3b74756-9b5d-45ec-b297-1e97b84cf131)
