### PR TITLE
ham: fixed out of range index when modifier == 1

### DIFF
--- a/_script/fileformats/iff.js
+++ b/_script/fileformats/iff.js
@@ -685,7 +685,7 @@ const IFF = (function () {
                     if (modifier) {
                         pixel <<= 8 - img.colorPlanes; // should the remaining (lower) bits also be filled?
                         color = prevColor.slice();
-                        if (modifier === 1) color[3] = pixel;
+                        if (modifier === 1) color[2] = pixel;
                         if (modifier === 2) color[0] = pixel;
                         if (modifier === 3) color[1] = pixel;
                     }


### PR DESCRIPTION
This probably fixes #39 and was spotted by @rcoenen

Before:
![image](https://github.com/user-attachments/assets/0dc0a9f7-a447-4251-a8e7-40263a435161)


After:
![image](https://github.com/user-attachments/assets/d67a92d2-b202-4a26-86f1-10fb5a40a771)
