### PR TITLE
Add Dockerfile, docker-compose and instruction (README-docker.md)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,6 @@
+# Using Docker to deploy DPaint-js
+Use Docker compose:
+```docker compose up --build```
+
+To run in detached/daemonized mode:
+```docker compose up -d --build```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION
This PR adds a basic Docker setup to deploy DPaint-js as a container for selfhosting.