### PR TITLE
Fix garbled rendering of lores interlaced ILBM files

### DIFF
--- a/_script/fileformats/iff.js
+++ b/_script/fileformats/iff.js
@@ -800,7 +800,10 @@ const IFF = (function () {
             })
         }
 
-        let imageData = new ImageData(img.width, img.height);
+        // Use canvas dimensions, not img dimensions, because lores interlaced
+        // files (interlaced && !hires) double canvas.width for pixel doubling.
+        // Using img.width here would cause pixel writes to overflow into wrong rows.
+        let imageData = new ImageData(canvas.width, canvas.height);
         let count = 0;
         for (let y = 0; y < img.height; y++) {
             const shamPalette = (img.shamPaletteByLine && img.shamPaletteByLine[y]) ? img.shamPaletteByLine[y] : null;


### PR DESCRIPTION
## Summary

- Fixes a bug where **lores interlaced ILBM files** (e.g. HAM6, CAMG `0x0804`) rendered with only the left half visible and severe scanline artifacts
- The `ImageData` buffer was allocated at `img.width` (320) but pixel indices were calculated using `canvas.width` (640, doubled for lores interlace pixel doubling), causing writes past x=160 to overflow into adjacent rows
- The fix simply uses `canvas.width`/`canvas.height` for the `ImageData` allocation so it matches the pixel write target

| Before Fix | After Fix |
|------------|-----------|
| <img alt="before_fix" src="https://github.com/user-attachments/assets/d8e0c743-666b-47eb-8465-3780de96a558" /> | <img width="1285" height="805" alt="after_fix" src="https://github.com/user-attachments/assets/db4ebeda-cfb3-4540-8117-b563182c1421" /> |

## How we found it

We tested with real-world HAM6 interlaced IFF images originally created in **Brilliance** on actual Amiga hardware (not emulators), sourced from the Amiga art community. These lores interlaced files exposed the bug — hires interlaced files (like HAM8 at 640px) were unaffected because `canvas.width` is not doubled in that case.

**Test file:** [Battle.lha](https://www.aminet.net/pix/jake/Battle.lha) from Aminet — contains **Battle.iff**, a HAM6 lores interlaced image (320×400, 6 planes, CAMG `0x0804`) created with Brilliance on an actual Amiga.

## Test plan

- [x] Tested with lores interlaced HAM6 files from Brilliance (320×400, CAMG `0x0804`) — now renders correctly full-width
- [x] Verified hires interlaced HAM8 files still render correctly (no regression — `canvas.width === img.width` in that path)
- [x] Verified standard non-interlaced files still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)